### PR TITLE
cpu: fix building for js

### DIFF
--- a/common.go
+++ b/common.go
@@ -23,8 +23,6 @@ import (
 	"strings"
 	"sync"
 	"time"
-
-	"golang.org/x/sys/cpu"
 )
 
 const (
@@ -1446,19 +1444,6 @@ func defaultCipherSuitesTLS13() []uint16 {
 
 func initDefaultCipherSuites() {
 	var topCipherSuites []uint16
-
-	// Check the cpu flags for each platform that has optimized GCM implementations.
-	// Worst case, these variables will just all be false.
-	var (
-		hasGCMAsmAMD64 = cpu.X86.HasAES && cpu.X86.HasPCLMULQDQ
-		hasGCMAsmARM64 = cpu.ARM64.HasAES && cpu.ARM64.HasPMULL
-		// Keep in sync with crypto/aes/cipher_s390x.go.
-		// TODO: check for s390
-		// hasGCMAsmS390X = cpu.S390X.HasAES && cpu.S390X.HasAESCBC && cpu.S390X.HasAESCTR && (cpu.S390X.HasGHASH || cpu.S390X.HasAESGCM)
-		hasGCMAsmS390X = false
-
-		hasGCMAsm = hasGCMAsmAMD64 || hasGCMAsmARM64 || hasGCMAsmS390X
-	)
 
 	if hasGCMAsm {
 		// If AES-GCM hardware is provided then prioritise AES-GCM

--- a/cpu.go
+++ b/cpu.go
@@ -1,0 +1,19 @@
+//go:build !js
+// +build !js
+
+package qtls
+
+import "golang.org/x/sys/cpu"
+
+// Check the cpu flags for each platform that has optimized GCM implementations.
+// Worst case, these variables will just all be false.
+var (
+	hasGCMAsmAMD64 = cpu.X86.HasAES && cpu.X86.HasPCLMULQDQ
+	hasGCMAsmARM64 = cpu.ARM64.HasAES && cpu.ARM64.HasPMULL
+	// Keep in sync with crypto/aes/cipher_s390x.go.
+	// TODO: check for s390
+	// hasGCMAsmS390X = cpu.S390X.HasAES && cpu.S390X.HasAESCBC && cpu.S390X.HasAESCTR && (cpu.S390X.HasGHASH || cpu.S390X.HasAESGCM)
+	hasGCMAsmS390X = false
+
+	hasGCMAsm = hasGCMAsmAMD64 || hasGCMAsmARM64 || hasGCMAsmS390X
+)

--- a/cpu_other.go
+++ b/cpu_other.go
@@ -1,0 +1,14 @@
+//go:build js
+// +build js
+
+package qtls
+
+// Check the cpu flags for each platform that has optimized GCM implementations.
+// Worst case, these variables will just all be false.
+var (
+	hasGCMAsmAMD64 = false
+	hasGCMAsmARM64 = false
+	hasGCMAsmS390X = false
+
+	hasGCMAsm = false
+)


### PR DESCRIPTION
Avoid importing the x/sys/cpu package for the js build tag.

Mark that CPU target has having none of the CPU features.

Fixes the build against gopherjs.